### PR TITLE
Add lower bound on aeson

### DIFF
--- a/ipynb.cabal
+++ b/ipynb.cabal
@@ -27,7 +27,7 @@ library
                      containers >= 0.5.8,
                      unordered-containers,
                      base64-bytestring,
-                     aeson,
+                     aeson >= 1.5.2.0,
                      bytestring,
                      text
   if impl(ghc < 8.0)


### PR DESCRIPTION
With older versions of aeson, the build fails with:

```
src/Data/Ipynb.hs:152:23: error:
    • No instance for (Ord Value)
        arising from the 'deriving' clause of a data type declaration
      Possible fix:
        use a standalone 'deriving instance' declaration,
          so you can specify the instance context yourself
    • When deriving the instance for (Ord JSONMeta)
    |
152 |   deriving (Show, Eq, Ord, Generic, Semigroup, Monoid, FromJSON)
    |                       ^^^

src/Data/Ipynb.hs:479:23: error:
    • No instance for (Ord Value)
        arising from the first field of ‘JsonData’ (type ‘Value’)
      Possible fix:
        use a standalone 'deriving instance' declaration,
          so you can specify the instance context yourself
    • When deriving the instance for (Ord MimeData)
    |
479 |   deriving (Show, Eq, Ord, Generic)
    |                       ^^^
cabal: Failed to build ipynb-0.2.
```